### PR TITLE
Remove GCC-only include

### DIFF
--- a/chr2png/src/main.cpp
+++ b/chr2png/src/main.cpp
@@ -2,7 +2,6 @@
 #include "import_defs.hpp"
 #include "shared.hpp"
 
-#include <bits/stdc++.h>
 #include <cerrno>
 #include <getopt.h>
 #include <iostream>

--- a/shared/src/defblocks.hpp
+++ b/shared/src/defblocks.hpp
@@ -1,7 +1,9 @@
 #ifndef DEFBLOCKS_H
 #define DEFBLOCKS_H
 
-#include <bits/stdc++.h>
+#include <fstream>
+#include <iostream>
+#include <istream>
 #include <cerrno>
 #include <map>
 #include <string>

--- a/shared/src/import_defs.hpp
+++ b/shared/src/import_defs.hpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <array>
-#include <bits/stdc++.h>
 #include <cerrno>
 #include <fstream>
 #include <map>


### PR DESCRIPTION
`bits/stdc++.h` is a GCC-only include that's not available on any other compiler. It's just an umbrella include that covers a bunch of other files, so this can be made portable just by replacing it by the specific includes it uses instead.

I've confirmed that I can build this via `clang++` on macOS with this patch.