### PR TITLE
Fix building and running on macOS; add 8x8 1bpp support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,13 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
   endif()
 endif()
 
+# Set rpath for macOS
+if(APPLE)
+    set(CMAKE_INSTALL_RPATH "@executable_path/../lib;/usr/local/lib")
+    set(CMAKE_BUILD_RPATH "${CMAKE_BINARY_DIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
+
 add_subdirectory(lib/chrgfx)
 
 if(NOT NO_UTILS)

--- a/lib/chrgfx/builtin_defs.cpp
+++ b/lib/chrgfx/builtin_defs.cpp
@@ -17,11 +17,15 @@ namespace chrgfx::gfxdefs
 using namespace std;
 
 // clang-format off
-/**
- * Minimal, generic CHR format
- * 1bpp 8x8
- */
-chrdef const chr_8x8_1bpp {"chr_8x8_1bpp", 8, 8, 1, {0}, {0, 1, 2, 3, 4, 5, 6, 7}, {0, 8, 16, 24, 32, 40, 48, 56}};
+chrdef const chr_8x8_1bpp {
+    "chr_8x8_1bpp",
+    8,
+    8,
+    1,
+    {0, 1, 2, 3, 4, 5, 6, 7},
+    {0, 8, 16, 24, 32, 40, 48, 56},
+    {0}
+};
 
 chrdef const chr_8x8_2bpp_packed_lsb {
 	"chr_8x8_2bpp_packed_lsb",
@@ -113,6 +117,7 @@ chrdef const chr_8x8_4bpp_planar {
 };
 
 map<string, chrdef const &> const chrdefs {
+	{chr_8x8_1bpp.id(), chr_8x8_1bpp},
 	{chr_8x8_2bpp_packed_lsb.id(), chr_8x8_2bpp_packed_lsb},
 	{chr_8x8_2bpp_packed_msb.id(), chr_8x8_2bpp_packed_msb},
 	{chr_8x8_4bpp_packed_msb.id(), chr_8x8_4bpp_packed_msb},


### PR DESCRIPTION
In addition to not being listed under `chrdefs`, the existing `chr_8x8_1bpp` chrdef had the plane_offsets before the pixel_offsets.